### PR TITLE
Api ordering

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -333,7 +333,7 @@ func (guild *GuildState) handleReactionGameStartAdd(s *discordgo.Session, m *dis
 					if playerData != nil {
 						guild.UserData.UpdatePlayerData(m.UserID, playerData)
 					} else {
-
+						log.Println("I couldn't find any player data for that color; is your capture linked?")
 					}
 
 					//then remove the player's reaction if we matched, or if we didn't

--- a/discord/guild.go
+++ b/discord/guild.go
@@ -59,6 +59,12 @@ type GuildState struct {
 	AmongUsData game.AmongUsData
 }
 
+type EmojiCollection struct {
+	statusEmojis  AlivenessEmojis
+	specialEmojis map[string]Emoji
+	lock          sync.RWMutex
+}
+
 // TrackedMemberAction struct
 type TrackedMemberAction struct {
 	mute          bool

--- a/discord/helpers.go
+++ b/discord/helpers.go
@@ -1,9 +1,12 @@
 package discord
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"github.com/bwmarrin/discordgo"
 	"github.com/denverquane/amongusdiscord/game"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -30,54 +33,138 @@ func (guild *GuildState) resetTrackedMembers(dg *discordgo.Session) {
 				}
 			}
 		} else { //the user doesn't exist in our userdata cache; add them
-			guild.checkCacheAndAddUser(g, voiceState.UserID)
+			guild.checkCacheAndAddUser(g, dg, voiceState.UserID)
 		}
 	}
 }
 
 func guildMemberReset(s *discordgo.Session, guildID string, userData game.UserData) {
-	guildMemberUpdate(s, guildID, userData.GetID(), UserPatchParameters{false, false, userData.GetOriginalNickName()}, 0)
+	guildMemberUpdate(s, UserPatchParameters{guildID, userData.GetID(), false, false, userData.GetOriginalNickName(), 0})
 }
 
 type UserPatchParameters struct {
-	Deaf bool   `json:"deaf"`
-	Mute bool   `json:"mute"`
-	Nick string `json:"nick"`
+	GuildID string
+	UserID  string
+	Deaf    bool
+	Mute    bool
+	Nick    string
+	Delay   int
 }
 
-func guildMemberUpdate(s *discordgo.Session, guildID string, userID string, params UserPatchParameters, delay int) {
-	g, err := s.Guild(guildID)
+func guildMemberUpdate(s *discordgo.Session, params UserPatchParameters) {
+	g, err := s.Guild(params.GuildID)
 	if err != nil {
 		log.Println(err)
 	}
 
-	if delay > 0 {
-		time.Sleep(time.Duration(delay) * time.Second)
+	if params.Delay > 0 {
+		time.Sleep(time.Duration(params.Delay) * time.Second)
 	}
 
 	//we can't nickname the owner, and we shouldn't nickname with an empty string...
-	if params.Nick == "" || g.OwnerID == userID {
-		guildMemberUpdateNoNick(s, guildID, userID, params)
+	if params.Nick == "" || g.OwnerID == params.UserID {
+		guildMemberUpdateNoNick(s, params)
 	} else {
-		log.Printf("Issuing update request to discord for userID %s with mute=%v deaf=%v nick=%s\n", userID, params.Mute, params.Deaf, params.Nick)
+		newParams := struct {
+			Deaf bool   `json:"deaf"`
+			Mute bool   `json:"mute"`
+			Nick string `json:"nick"`
+		}{params.Deaf, params.Mute, params.Nick}
+		log.Printf("Issuing update request to discord for userID %s with mute=%v deaf=%v nick=%s\n", params.UserID, params.Mute, params.Deaf, params.Nick)
 
-		_, err := s.RequestWithBucketID("PATCH", discordgo.EndpointGuildMember(guildID, userID), params, discordgo.EndpointGuildMember(guildID, ""))
+		_, err := s.RequestWithBucketID("PATCH", discordgo.EndpointGuildMember(params.GuildID, params.UserID), newParams, discordgo.EndpointGuildMember(params.GuildID, ""))
 		if err != nil {
 			log.Println("Failed to change nickname for user: move the bot up in your Roles")
 			log.Println(err)
-			guildMemberUpdateNoNick(s, guildID, userID, params)
+			guildMemberUpdateNoNick(s, params)
 		}
 	}
 }
 
-func guildMemberUpdateNoNick(s *discordgo.Session, guildID string, userID string, params UserPatchParameters) {
-	log.Printf("Issuing update request to discord for userID %s with mute=%v deaf=%v\n", userID, params.Mute, params.Deaf)
+func guildMemberUpdateNoNick(s *discordgo.Session, params UserPatchParameters) {
+	log.Printf("Issuing update request to discord for userID %s with mute=%v deaf=%v\n", params.UserID, params.Mute, params.Deaf)
 	newParams := struct {
 		Deaf bool `json:"deaf"`
 		Mute bool `json:"mute"`
 	}{params.Deaf, params.Mute}
-	_, err := s.RequestWithBucketID("PATCH", discordgo.EndpointGuildMember(guildID, userID), newParams, discordgo.EndpointGuildMember(guildID, ""))
+	_, err := s.RequestWithBucketID("PATCH", discordgo.EndpointGuildMember(params.GuildID, params.UserID), newParams, discordgo.EndpointGuildMember(params.GuildID, ""))
 	if err != nil {
 		log.Println(err)
 	}
+}
+
+func getPhaseFromArgs(args []string) game.Phase {
+	if len(args) == 0 {
+		return game.UNINITIALIZED
+	}
+
+	phase := strings.ToLower(args[0])
+	switch phase {
+	case "lobby":
+		fallthrough
+	case "l":
+		return game.LOBBY
+	case "task":
+		fallthrough
+	case "t":
+		fallthrough
+	case "tasks":
+		fallthrough
+	case "game":
+		fallthrough
+	case "g":
+		return game.TASKS
+	case "discuss":
+		fallthrough
+	case "disc":
+		fallthrough
+	case "d":
+		fallthrough
+	case "discussion":
+		return game.DISCUSS
+	default:
+		return game.UNINITIALIZED
+
+	}
+}
+
+// GetRoomAndRegionFromArgs does what it sounds like
+func getRoomAndRegionFromArgs(args []string) (string, string) {
+	if len(args) == 0 {
+		return "Unprovided", "Unprovided"
+	}
+	room := strings.ToUpper(args[0])
+	if len(args) == 1 {
+		return room, "Unprovided"
+	}
+	region := strings.ToLower(args[1])
+	switch region {
+	case "na":
+		fallthrough
+	case "us":
+		fallthrough
+	case "usa":
+		fallthrough
+	case "north":
+		region = "North America"
+	case "eu":
+		fallthrough
+	case "europe":
+		region = "Europe"
+	case "as":
+		fallthrough
+	case "asia":
+		region = "Asia"
+	}
+	return room, region
+}
+
+func generateConnectCode(guildID string) string {
+	h := sha256.New()
+	h.Write([]byte(guildID))
+	//add some "randomness" with the current time
+	h.Write([]byte(time.Now().String()))
+	hashed := strings.ToUpper(hex.EncodeToString(h.Sum(nil))[0:6])
+	//TODO replace common problematic characters?
+	return strings.ReplaceAll(strings.ReplaceAll(hashed, "I", "1"), "O", "0")
 }

--- a/discord/message_handlers.go
+++ b/discord/message_handlers.go
@@ -1,14 +1,18 @@
 package discord
 
 import (
+	"github.com/denverquane/amongusdiscord/game"
 	"log"
 
 	"github.com/bwmarrin/discordgo"
 )
 
 func (guild *GuildState) handleGameEndMessage(s *discordgo.Session) {
+	guild.AmongUsData.SetAllAlive()
+	guild.AmongUsData.SetPhase(game.LOBBY)
+
 	// apply the unmute/deafen to users who have state linked to them
-	guild.resetTrackedMembers(s)
+	guild.handleTrackedMembers(s, 0, NoPriority)
 
 	//clear the tracking and make sure all users are unlinked
 	guild.clearGameTracking(s)

--- a/discord/voiceBehavior.go
+++ b/discord/voiceBehavior.go
@@ -87,37 +87,3 @@ func MakeMuteOnlyRules() VoiceRules {
 	}
 	return rules
 }
-
-//func MakeMuteOnlyRules() VoiceRules {
-//	rules := VoiceRules{
-//		MuteRules: map[game.Phase]map[bool]bool{
-//			game.LOBBY: map[bool]bool{
-//				true:  false,
-//				false: false,
-//			},
-//			game.TASKS: map[bool]bool{
-//				true:  true,
-//				false: true,
-//			},
-//			game.DISCUSS: map[bool]bool{
-//				true:  false,
-//				false: true,
-//			},
-//		},
-//		DeafRules: map[game.Phase]map[bool]bool{
-//			game.LOBBY: map[bool]bool{
-//				true:  false,
-//				false: false,
-//			},
-//			game.TASKS: map[bool]bool{
-//				true:  false,
-//				false: false,
-//			},
-//			game.DISCUSS: map[bool]bool{
-//				true:  false,
-//				false: false,
-//			},
-//		},
-//	}
-//	return rules
-//}

--- a/game/state.go
+++ b/game/state.go
@@ -49,15 +49,3 @@ type Player struct {
 	IsDead       bool         `json:"IsDead"`
 	Disconnected bool         `json:"Disconnected"`
 }
-
-// PlayerUpdate struct
-type PlayerUpdate struct {
-	Player  Player
-	GuildID string
-}
-
-// PhaseUpdate struct
-type PhaseUpdate struct {
-	Phase   Phase
-	GuildID string
-}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-const VERSION = "2.1.1-Prerelease"
+const VERSION = "2.2.0-Prerelease"
 
 const DefaultPort = "8123"
 


### PR DESCRIPTION
Prioritize applying changes to users who need to be muted/unmuted first to prevent overlap between users who shouldn't be able to hear eachother. Synchronously wait for ALL users to have voice changes applied BEFORE updating the status message (Rate-limiting considerations)