### PR TITLE
Added "Deploy to Heroku" Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ You can also run the discord portion using docker if you prefer, it simply needs
 Example:
 `docker run -p 8123:8123 -e DISCORD_BOT_TOKEN=<YourTokenHere> denverquane/amongusdiscord`
 
+## Deploy to Heroku
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+The app will fail the first time you deploy since the `DISCORD_BOT_TOKEN` is not set. To fix this:
+
+1. Create a new Config var in your Heroku app's settings with the key `DISCORD_BOT_TOKEN` and the value as your bot token obtained from the pre-installation step.
+2. Restart all dynos
+
+To connect to this deployment, create a `host.txt` file in the same folder as the  `amonguscapture.exe` file with the contents `https://<host>`, where the host is your Heroku app URL and restart `amonguscapture.exe` if its already running.
+
 # Sample Usage
 To start the bot in the current channel, type the following `.au` commands in Discord:
 ```

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+    "name": "AmongUsAutoMute (BETA)",
+    "description": "Discord Bot to scrape Among Us on-screen data, and automatically mute/unmute players during the course of the game!",
+    "repository": "https://github.com/denverquane/amongusdiscord",
+    "logo": "https://github.com/denverquane/amongusdiscord/raw/master/assets/botProfilePicture.jpg",
+    "keywords": ["go", "among us", "discord"]
+  }

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func discordMainWrapper() error {
 		shardID = -1
 	}
 
-	port := os.Getenv("SERVER_PORT")
+	port := os.Getenv("PORT")
 	num, err := strconv.Atoi(port)
 	if err != nil || num < 1024 || num > 65535 {
 		log.Printf("Invalid or no particular SERVER_PORT (range [1024-65535]) provided. Defaulting to %s\n", DefaultPort)

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func discordMainWrapper() error {
 	port := os.Getenv("PORT")
 	num, err := strconv.Atoi(port)
 	if err != nil || num < 1024 || num > 65535 {
-		log.Printf("Invalid or no particular SERVER_PORT (range [1024-65535]) provided. Defaulting to %s\n", DefaultPort)
+		log.Printf("Invalid or no particular PORT (range [1024-65535]) provided. Defaulting to %s\n", DefaultPort)
 		port = DefaultPort
 	}
 


### PR DESCRIPTION
Added the ability for users to be able to easily deploy the Among Us discord bot to Heroku.

Not sure why the env var "SERVER_PORT" was picked but changing it to "PORT" allows the app to easily work with Heroku.