### PR TITLE
Allow overriding external port in SERVER_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # final config file
 final.txt
 final.env
+config.txt
 
 # logs file
 logs.txt

--- a/discord/message_handlers.go
+++ b/discord/message_handlers.go
@@ -3,6 +3,7 @@ package discord
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/denverquane/amongusdiscord/game"
@@ -45,22 +46,32 @@ func (bot *Bot) handleNewGameMessage(guild *GuildState, s *discordgo.Session, m 
 	bot.LinkCodeLock.Unlock()
 
 	var hyperlink string
-	var hyperlinkPort string
-	if bot.extPort != "" {
-		if bot.extPort == "protocol" {
-			hyperlinkPort = ""
-		} else {
-			hyperlinkPort = ":" + bot.extPort
+	urlregex := regexp.MustCompile(`http(?P<secure>s?)://(?P<host>[^:]*):?(?P<port>.*)`)
+	if match := urlregex.FindStringSubmatch(bot.url); match != nil {
+		secure := match[urlregex.SubexpIndex("secure")] == "s"
+		host := match[urlregex.SubexpIndex("host")]
+		port := ":" + match[urlregex.SubexpIndex("port")]
+
+		if port == ":" {
+			if bot.extPort != "" {
+				if bot.extPort == "protocol" {
+					port = ""
+				} else {
+					port = ":" + bot.extPort
+				}
+			} else {
+				port = ""
+			}
 		}
+
+		insecure := "?insecure"
+		if secure {
+			insecure = ""
+		}
+
+		hyperlink = fmt.Sprintf("aucapture://%s%s/%s%s", host, port, connectCode, insecure)
 	} else {
-		hyperlinkPort = ":" + bot.socketPort
-	}
-	if strings.HasPrefix(bot.url, "https://") {
-		hyperlink = fmt.Sprintf("aucapture://%s%s/%s", strings.Replace(bot.url, "https://", "", 1), hyperlinkPort, connectCode)
-	} else if strings.HasPrefix(bot.url, "http://") {
-		hyperlink = fmt.Sprintf("aucapture://%s%s/%s?insecure", strings.Replace(bot.url, "http://", "", 1), hyperlinkPort, connectCode)
-	} else {
-		hyperlink = "aucapture://INVALID_PROTOCOL_ON_SERVER_URL"
+		hyperlink = "aucapture://INVALID_SERVER_URL"
 	}
 
 	var embed = discordgo.MessageEmbed{

--- a/discord/message_handlers.go
+++ b/discord/message_handlers.go
@@ -46,7 +46,7 @@ func (bot *Bot) handleNewGameMessage(guild *GuildState, s *discordgo.Session, m 
 	bot.LinkCodeLock.Unlock()
 
 	var hyperlink string
-	urlregex := regexp.MustCompile(`http(?P<secure>s?)://(?P<host>[^:]*):?(?P<port>.*)`)
+	urlregex := regexp.MustCompile(`^http(?P<secure>s?):\/\/(?P<host>[\w.-]+)(?::(?P<port>\d+))?$`)
 	if match := urlregex.FindStringSubmatch(bot.url); match != nil {
 		secure := match[urlregex.SubexpIndex("secure")] == "s"
 		host := match[urlregex.SubexpIndex("host")]


### PR DESCRIPTION
This allows setting
`SERVER_URL=https://api.example.com:8443`
instead of
`SERVER_URL=https://api.example.com` and
`EXT_PORT=8443`