### PR TITLE
Update voice status using "Channel Workers"

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -141,6 +141,38 @@ func (guild *GuildState) handleTrackedMembers(sm *SessionManager, delay int, han
 	priorityQueue := &PatchPriority{}
 	heap.Init(priorityQueue)
 
+	// amountWorkers value determines how many goroutines will be spawned to mute users
+	// this amount could be increased up to 10, but 8 should be enough
+	const amountWorkers = 8
+
+	// wait group
+	wgWorkers := sync.WaitGroup{}
+	wgWorkers.Add(amountWorkers)
+
+	// buffered channel of size 10 (maximum numbers os players in a match)
+	userChan := make(chan UserPatchParameters, 10)
+
+	// starts workers, aka channel receivers
+	for i := 0; i < amountWorkers; i++ {
+		// Receive values until userChan is
+		// closed and the value buffer queue
+		// of userChan becomes empty.
+		go func() {
+			defer wgWorkers.Done()
+
+			// read messages from the channel and act on them
+			for parameters := range userChan {
+				guildMemberUpdate(sm.GetSessionForRequest(), parameters)
+				log.Println(parameters)
+			}
+		}()
+	}
+
+	if delay > 0 {
+		log.Printf("Sleeping for %d seconds before applying changes to users\n", delay)
+		time.Sleep(time.Second * time.Duration(delay))
+	}
+
 	for _, voiceState := range g.VoiceStates {
 
 		userData, err := guild.UserData.GetUser(voiceState.UserID)
@@ -170,22 +202,15 @@ func (guild *GuildState) handleTrackedMembers(sm *SessionManager, delay int, han
 
 			//only issue the req to discord if we're not waiting on another one
 			if !userData.IsPendingVoiceUpdate() {
-				priority := 0
+				//wait until it goes through
+				userData.SetPendingVoiceUpdate(true)
 
-				if handlePriority != NoPriority {
-					if handlePriority == AlivePriority && userData.IsAlive() {
-						priority++
-					} else if handlePriority == DeadPriority && !userData.IsAlive() {
-						priority++
-					}
-				}
+				guild.UserData.UpdateUserData(voiceState.UserID, userData)
 
 				params := UserPatchParameters{guild.PersistentGuildData.GuildID, userData, shouldDeaf, shouldMute, nick}
 
-				heap.Push(priorityQueue, PrioritizedPatchParams{
-					priority:    priority,
-					patchParams: params,
-				})
+				// send params to worker
+				userChan <- params
 			}
 
 		} else if userData.IsLinked() {
@@ -196,45 +221,14 @@ func (guild *GuildState) handleTrackedMembers(sm *SessionManager, delay int, han
 			}
 		}
 	}
-	wg := sync.WaitGroup{}
-	waitForHigherPriority := false
 
-	if delay > 0 {
-		log.Printf("Sleeping for %d seconds before applying changes to users\n", delay)
-		time.Sleep(time.Second * time.Duration(delay))
-	}
+	// Close channel because all users were sent
+	close(userChan)
 
-	for priorityQueue.Len() > 0 {
-		p := heap.Pop(priorityQueue).(PrioritizedPatchParams)
-
-		if p.priority > 0 {
-			waitForHigherPriority = true
-			log.Printf("User %s has higher priority: %d\n", p.patchParams.Userdata.GetID(), p.priority)
-		} else if waitForHigherPriority {
-			//wait for all the other users to get muted/unmuted completely, first
-			//log.Println("Waiting for high priority user changes first")
-			wg.Wait()
-			waitForHigherPriority = false
-		}
-
-		wg.Add(1)
-
-		//wait until it goes through
-		p.patchParams.Userdata.SetPendingVoiceUpdate(true)
-
-		guild.UserData.UpdateUserData(p.patchParams.Userdata.GetID(), p.patchParams.Userdata)
-
-		//we can issue mutes/deafens from ANY session, not just the primary
-		go muteWorker(sm.GetSessionForRequest(), &wg, p.patchParams)
-	}
-	wg.Wait()
+	// wait for all workers to close
+	wgWorkers.Wait()
 
 	return
-}
-
-func muteWorker(s *discordgo.Session, wg *sync.WaitGroup, parameters UserPatchParameters) {
-	guildMemberUpdate(s, parameters)
-	wg.Done()
 }
 
 func (guild *GuildState) verifyVoiceStateChanges(s *discordgo.Session) *discordgo.Guild {


### PR DESCRIPTION
## Change Proposal

This PR changes the way the Voice States are updated.

### Why?

The current procedure is slow, and unnecessarily complicated.
I've tested a few different ways to do this, and came to the conclusion that the priority queue slows down this process, and although it is possible to have both the priority queue and the "worker", it only makes the process slower.

I invite you to test this for yourself, but I understand this is hard to measure. I've spent a few hours testing with a 10 players party (they were very patient).

### How it was:
Users were given a priority ranking, inserted in a heap, and later poped from it, and a sync group was used to ensure the higher priority users were updated first.

### How it is done in this proposal :

A number of "workers" are started, each one in a different go routine. Each one is capable of updating every user, but instead, they receive parameters trough a Channel, and do the updating concurrently. Once the channel is closed, and empty, the workers are dropped from existence .
