### PR TITLE
Fix heroku deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/denverquane/amongusdiscord
 
+// +heroku goVersion go1.15
 go 1.15
 
 require (


### PR DESCRIPTION
Fix heroku defaulting to go version 1.12 (If I remember correctly) and build failing with exception
`(type *regexp.Regexp has no field or method SubexpIndex)`