### PR TITLE
Fix go version requirement for Heroku

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/denverquane/amongusdiscord
 
-go 1.15
+// +heroku goVersion go1.15
 
 require (
 	cloud.google.com/go/firestore v1.3.0


### PR DESCRIPTION
Current go.mod's method of requiring go 1.15 doesn't seem to work with Heroku; it still deploys 1.12 which causes the build to fail:
```
-----> Go app detected
-----> Fetching jq... done
-----> Fetching stdlib.sh.v8... done
-----> 
       Detected go modules via go.mod
-----> 
       Detected Module Name: github.com/denverquane/amongusdiscord
-----> 
 !!    The go.mod file for this project does not specify a Go version
 !!    
 !!    Defaulting to go1.12.17
 !!    
 !!    For more details see: https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration
 !!    
-----> New Go Version, clearing old cache
-----> Installing go1.12.17
-----> Fetching go1.12.17.linux-amd64.tar.gz... done
...
discord/message_handlers.go:55:27: urlregex.SubexpIndex undefined (type *regexp.Regexp has no field or method SubexpIndex)
discord/message_handlers.go:56:25: urlregex.SubexpIndex undefined (type *regexp.Regexp has no field or method SubexpIndex)
discord/message_handlers.go:57:31: urlregex.SubexpIndex undefined (type *regexp.Regexp has no field or method SubexpIndex)
note: module requires Go 1.15
 !     Push rejected, failed to compile Go app.
 !     Push failed
```

Changing the line to `// +heroku goVersion go1.15` and rebuilding works