### PR TITLE
Modify app.json to include GOVERSION and all environment variables

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,19 +6,33 @@
     "keywords": ["go", "among us", "discord"],
     "env": {
       "DISCORD_BOT_TOKEN": {
-
+        "description": "The Bot Token used by the bot to authenticate with Discord.",
+        "required": true
       },
       "DISCORD_BOT_TOKEN_2": {
-
+        "description": "The optional second bot token used by the bot to avoid Discord API rate limiting. Recommended with large groups (8+) people to speed up muting/unmuting.",
+        "required": false
       },
       "EXT_PORT": {
-
+        "description": "The port to use for the capture url. Must be a valid port number, or \"protocol\" to not include a port in the url. Defaults to PORT.",
+        "required": false
       },
       "SERVER_URL": {
-
+        "description": "The externally-accessible URL for this instance of the discord bot. For example, http://test.com. This is used to provide the linking URI to the capture, via the Direct Message the bot sends you when typing .au new (in conjunction with the PORT above). You must specify http:// or https:// accordingly as part of the URL",
+        "required": false
       },
       "GOVERSION": {
-        
+        "description": "Default Go version to use for Heroku deployment. Defaults to Go 1.15. Required to be >= 1.13 for package purposes.",
+        "value": "1.15",
+        "required": false
+      },
+      "CONFIG_PATH": {
+        "description": "Alternate filesystem path for guild config files. Defaults to ./",
+        "required": false
+      },
+      "NUM_SHARDS": {
+        "description": "How many total bot shard instances you'll be running in your current stack.",
+        "required": false
       }
     }
   }

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "name": "AmongUsAutoMute (BETA)",
-    "description": "Discord Bot to scrape Among Us on-screen data, and automatically mute/unmute players during the course of the game!",
+    "description": "Discord Bot to harness Among Us game data, and automatically mute/unmute players during the course of the game!",
     "repository": "https://github.com/denverquane/amongusdiscord",
     "logo": "https://github.com/denverquane/amongusdiscord/raw/master/assets/botProfilePicture.jpg",
     "keywords": ["go", "among us", "discord"],
@@ -18,7 +18,7 @@
         "required": false
       },
       "PORT": {
-        "description": "The port the Bot will use for incoming Socket.io communications from the capture client. Defaults to 8123. You must specify more (comma-delimited ports) if you are running with NUM_SHARDS > 1. For example, with 3 shards, PORT = 8123,8124,8125",
+        "description": "The port the Bot will use for incoming Socket.io communications from the capture client. Defaults to 8123.",
         "required": false
       },
       "EXT_PORT": {
@@ -36,10 +36,6 @@
       },
       "CONFIG_PATH": {
         "description": "Alternate filesystem path for guild config files. Defaults to ./",
-        "required": false
-      },
-      "NUM_SHARDS": {
-        "description": "How many total bot shard instances you'll be running in your current stack.",
         "required": false
       }
     }

--- a/app.json
+++ b/app.json
@@ -3,5 +3,22 @@
     "description": "Discord Bot to scrape Among Us on-screen data, and automatically mute/unmute players during the course of the game!",
     "repository": "https://github.com/denverquane/amongusdiscord",
     "logo": "https://github.com/denverquane/amongusdiscord/raw/master/assets/botProfilePicture.jpg",
-    "keywords": ["go", "among us", "discord"]
+    "keywords": ["go", "among us", "discord"],
+    "env": {
+      "DISCORD_BOT_TOKEN": {
+
+      },
+      "DISCORD_BOT_TOKEN_2": {
+
+      },
+      "EXT_PORT": {
+
+      },
+      "SERVER_URL": {
+
+      },
+      "GOVERSION": {
+        
+      }
+    }
   }

--- a/app.json
+++ b/app.json
@@ -13,6 +13,14 @@
         "description": "The optional second bot token used by the bot to avoid Discord API rate limiting. Recommended with large groups (8+) people to speed up muting/unmuting.",
         "required": false
       },
+      "EMOJI_GUILD_ID": {
+        "description": "If your bot is a member of multiple guilds, this ID can be used to specify the single guild that it should use for emojis (no need to add the emojis to ALL servers).",
+        "required": false
+      },
+      "PORT": {
+        "description": "The port the Bot will use for incoming Socket.io communications from the capture client. Defaults to 8123. You must specify more (comma-delimited ports) if you are running with NUM_SHARDS > 1. For example, with 3 shards, PORT = 8123,8124,8125",
+        "required": false
+      },
       "EXT_PORT": {
         "description": "The port to use for the capture url. Must be a valid port number, or \"protocol\" to not include a port in the url. Defaults to PORT.",
         "required": false
@@ -24,7 +32,7 @@
       "GOVERSION": {
         "description": "Default Go version to use for Heroku deployment. Defaults to Go 1.15. Required to be >= 1.13 for package purposes.",
         "value": "1.15",
-        "required": false
+        "required": true
       },
       "CONFIG_PATH": {
         "description": "Alternate filesystem path for guild config files. Defaults to ./",


### PR DESCRIPTION
This modified app.json fixes the need to restart the app immediately after deployment by specifying the necessary environment variables before deployment. 

It also fixes the build issue where Heroku defaults to an older version of Go by automatically selecting Go 1.15 using the GOVERSION env var. This way, instead of modifying go.mod, all Heroku deployment information can stay within app.json.

The deployment also requires that you have at least one Discord bot token before building the app. 

I was able to successfully deploy this app on Heroku using this app.json and communicate with the capture using the DM link sent. 

Current Heroku deployment page:
![image](https://user-images.githubusercontent.com/22385070/95684935-5a324a80-0bba-11eb-8b50-c571b831ae9e.png)

Proposed Heroku deployment page:
![image](https://user-images.githubusercontent.com/22385070/95684968-8b127f80-0bba-11eb-8a56-8761982c07a9.png)


