### PR TITLE
Fix HasRolePerms

### DIFF
--- a/storage/guildSettings.go
+++ b/storage/guildSettings.go
@@ -56,7 +56,7 @@ func (gs *GuildSettings) HasAdminPerms(mem *discordgo.Member) bool {
 }
 
 func (gs *GuildSettings) HasRolePerms(mem *discordgo.Member) bool {
-	if len(gs.PermissionRoleIDs) == 0 || mem.User == nil {
+	if len(gs.PermissionRoleIDs) == 0 {
 		return false
 	}
 


### PR DESCRIPTION
So this is part of a larger issue, and fixes it partially:

The `HasAdminPerms` and `HasRolePerms` functions take a guild Member from bot.py's message handler:

https://github.com/denverquane/amongusdiscord/blob/137dc9ac234ccc3a6a54342510e9d515d1c0d1a5/discord/bot.go#L964

While the `Member` property does come from the MessageCreate event and is available, the `User` property on it is missing. This is documented in the [Discord GuildMember docs](https://discord.com/developers/docs/resources/guild#guild-member-object):

> The field user `user` won't be included in the member object attached to `MESSAGE_CREATE` and `MESSAGE_UPDATE` gateway events.

So what that means is right now, all calls to `HasAdminPerms` and `HasRolePerms` are failing, as `mem.User` is nil. To fix this we would probably have to resort back to passing the User object obtained from Message.Author instead of the Message.Member here.

In the meantime, this PR fixes at `HasRolePerms` as `mem.User` is not required for the role check (roles are attached directly to the Member). Is presume this was added in an abundance of caution after a similar check was added to `HasAdminPerms`, as it was presumably crashing due to the absence of the User property.

Refs #183.